### PR TITLE
Publish CI test reports (annotations + artifact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+  checks: write # the JUnit annotator creates a check run with the failures
+  pull-requests: write # ...and annotates them on the PR
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,3 +50,23 @@ jobs:
           # (e.g. count per site, or assert >= 1).
           [ ${#chrome[@]} -eq 1 ] || { echo "::error::expected exactly one Chrome zip, found ${#chrome[@]}"; exit 1; }
           [ ${#firefox[@]} -eq 1 ] || { echo "::error::expected exactly one Firefox zip, found ${#firefox[@]}"; exit 1; }
+
+      # Reads the JUnit XML and surfaces failed tests inline (check run + PR
+      # annotations). `always()` so it still reports when "Build and test" failed.
+      - name: Publish test results
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: '**/build/test-results/**/*.xml'
+
+      # Full HTML report + raw XML as a run-scoped artifact, downloadable from
+      # the run page (expires after retention). `always()` — kept on every run.
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          retention-days: 14


### PR DESCRIPTION
Adds two steps to the CI workflow:

- **JUnit annotator** (`mikepenz/action-junit-report@v6`) — reads the test XML and surfaces failed tests inline as a check run + PR annotations.
- **Artifact upload** (`actions/upload-artifact@v7`) — uploads the HTML report + raw XML as a run-scoped `test-reports` artifact, on every run (`always()`).

Plus the `checks` / `pull-requests: write` permissions the annotator needs.

This PR self-tests the setup: the workflow runs from this branch, so the new steps execute on this very PR.
