### PR TITLE
Refresh the popup list when a topic is read

### DIFF
--- a/popup/src/jsMain/kotlin/Main.kt
+++ b/popup/src/jsMain/kotlin/Main.kt
@@ -9,6 +9,7 @@ import flags.chrome.ensureBrowserNamespace
 import flags.chrome.i18n.getMessage
 import flags.chrome.runtime.openOptionsPage
 import flags.chrome.runtime.sendMessage
+import flags.chrome.storage.onChanged
 import flags.chrome.tabs.Companion.CreateProperties
 import flags.chrome.tabs.Companion.UpdateProperties
 import flags.chrome.tabs.create
@@ -49,6 +50,15 @@ fun main() {
     // Render the cached snapshot immediately, then refine as the stores resolve.
     snapshotStore.load().then { snapshot = it }
     prefsStore.load().then { prefs = it }
+
+    // Live-refresh the list: opening a topic schedules a worker re-poll
+    // (REFRESH_SOON) that rewrites the cached snapshot once the topic reads as
+    // seen — reload it so an open popup drops that topic, like v1 did.
+    onChanged.addListener { changes, areaName ->
+        if (areaName == "local" && changes != null && changes[SnapshotStore.KEY] != undefined) {
+            snapshotStore.load().then { snapshot = it }
+        }
+    }
 
     fun refresh() {
         if (refreshing) return

--- a/worker/src/jsMain/kotlin/flags/Main.kt
+++ b/worker/src/jsMain/kotlin/flags/Main.kt
@@ -37,9 +37,15 @@ import kotlin.math.max
 
 private const val ALARM = "forum-flags-alarm"
 
-/** One-shot alarm armed after the popup opens links, to re-poll shortly after. */
-private const val SOON_ALARM = "forum-flags-refresh-soon"
-private const val SOON_DELAY_MINUTES = 0.1
+/**
+ * Delay before the catch-up re-poll after the popup opens links. Driven by
+ * setTimeout, NOT chrome.alarms: alarms clamp sub-minute delays to ~30–60s
+ * (far too late to feel live), whereas the worker is still alive right after
+ * the message, so a short timeout fires on time.
+ */
+private const val SOON_DELAY_MS = 1000
+
+private external fun setTimeout(handler: () -> Unit, timeoutMs: Int): Int
 
 /** Id of the optional context-menu refresh entry. */
 private const val MENU_ID = "forum-flags-refresh"
@@ -166,8 +172,8 @@ fun main() {
                 true // keep the channel open for the asynchronous sendResponse above
             }
             Messages.REFRESH_SOON.name -> {
-                // Re-poll a little later (one-shot), no reply needed.
-                create(SOON_ALARM, AlarmCreateInfo { delayInMinutes = SOON_DELAY_MINUTES })
+                // Re-poll shortly after, no reply needed (see SOON_DELAY_MS).
+                setTimeout({ refresh().catch { e -> console.warn("forum-flags: refresh failed", e) } }, SOON_DELAY_MS)
                 false
             }
             else -> false


### PR DESCRIPTION
Restores v1's behavior: after opening a topic, it leaves the list once read.

The worker already re-polls a few seconds after a click (`REFRESH_SOON`) and rewrites the cached snapshot — the popup just never reacted to it. This subscribes the popup to `storage.onChanged` for the snapshot key, so an **open** popup re-renders and drops the read topic.
  
Notes:
- Only affects a popup that stays open; if it closes on click, reopening already loads the fresh snapshot.
- Depends on the re-poll landing after the forum marks the topic read (`SOON_DELAY_MINUTES`, currently ~6s) — to tune if it proves too eager.
