### PR TITLE
derive the project version from git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history + tags, so git-versioning resolves the version
 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history + tags, so git-versioning resolves the tag
 
       - uses: actions/setup-java@v5
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,22 @@
 plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.git.versioning)
 }
 
 allprojects {
     group = "com.myflags"
-    version = "2.0.0"
+}
+
+// Version derived entirely from git (propagated to every module by the plugin):
+// a `vX.Y.Z` tag -> `X.Y.Z`; any other ref (branch, detached HEAD) -> the short
+// commit SHA. No literal fallback — without git it stays Gradle's "unspecified".
+gitVersioning.apply {
+    refs {
+        tag("v(?<version>[0-9].*)") { version = "\${ref.version}" }
+        branch(".+") { version = "\${commit.short}" }
+    }
+    rev { version = "\${commit.short}" }
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 
-org.gradle.configuration-cache=true
+# Off because git-versioning reads git (version) at configuration time, which
+# the configuration cache forbids (no external processes during configuration).
+org.gradle.configuration-cache=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.3.21"
 compose-plugin = "1.11.1"
+gitVersioning = "6.4.4"
 
 [libraries]
 compose-html-core = { module = "org.jetbrains.compose.html:html-core", version.ref = "compose-plugin" }
@@ -9,4 +10,5 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+git-versioning = { id = "me.qoomon.git-versioning", version.ref = "gitVersioning" }
 

--- a/package/build.gradle.kts
+++ b/package/build.gradle.kts
@@ -26,6 +26,13 @@ val assembleCommon by tasks.registering(Copy::class) {
 /** The dual-key manifest; each browser build strips it down to its clean form. */
 val baseManifestFile = layout.projectDirectory.file("src/main/resources/manifest.json").asFile
 
+// The manifest version must be numeric (Chrome/FF reject a SHA): use the Gradle
+// version on a `vX.Y.Z` tag build, else fall back to 0.0.0 — branch builds carry
+// the commit short SHA as their version (see git-versioning in the root build).
+val manifestVersion = project.version.toString().let {
+    if (it.matches(Regex("""\d+(\.\d+){0,3}"""))) it else "0.0.0"
+}
+
 val browsers = listOf("chrome", "firefox")
 
 browsers.forEach { browser ->
@@ -39,12 +46,15 @@ browsers.forEach { browser ->
         // `baseManifestFile` is a script-level val; capture it into a local so the
         // task body doesn't reference the script object (configuration-cache safe).
         val base = baseManifestFile
+        val ver = manifestVersion
         val isChrome = browser == "chrome"
         inputs.file(base)
+        inputs.property("version", ver)
         outputs.file(manifestOutFile)
         doLast {
             @Suppress("UNCHECKED_CAST")
             val manifest = JsonSlurper().parse(base) as MutableMap<String, Any?>
+            manifest["version"] = ver
             @Suppress("UNCHECKED_CAST")
             val background = manifest["background"] as MutableMap<String, Any?>
             if (isChrome) {

--- a/package/src/main/resources/manifest.json
+++ b/package/src/main/resources/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "HFR - Mes sujets",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "Vérifie si les sujets drapalisés sur forum.hardware.fr ont de nouveaux messages.",
   "manifest_version": 3,
   "default_locale": "fr",


### PR DESCRIPTION
Adds [qoomon git-versioning](https://github.com/qoomon/gradle-git-versioning-plugin) (6.4.4) so the Gradle version comes from git:

- a `vX.Y.Z` **tag** → version `X.Y.Z`
- any other ref (**branch**, detached HEAD) → the short commit SHA
  
This flows into the zip names (`package-chrome-<version>.zip`).
  
**Manifest version** is also propagated (injected during manifest generation in `package/build.gradle.kts`). Browser manifests require a numeric version, so it uses the Gradle version when numeric (tag builds) and falls back to `0.0.0` otherwise (branch builds carry a SHA, which Chrome/Firefox reject). The source `manifest.json` now carries `0.0.0` as a build-managed placeholder.
  
**CI**: both workflows now checkout with `fetch-depth: 0` so the plugin can see tags/history — otherwise a release build wouldn't resolve the tag and would ship a SHA/`0.0.0`. 
  
Verified locally: on this branch the version resolves to the short SHA, manifests get `0.0.0`, zips are named accordingly; on a tag it would be `X.Y.Z`.
